### PR TITLE
install a fixed range versions of the jms/serializer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.3.3",
         "webit/soap-api": "^3.0",
-        "jms/serializer": "^3.0"
+        "jms/serializer": ">3.20 <3.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.6.0"


### PR DESCRIPTION
This pull request addresses an issue with the jms/serializer library when working with PHP 8.3. Previously, the dependency was defined as "jms/serializer": "^3.0", but starting from version 3.3, the serialization process began to fail due to a syntax change that caused object fields not to populate correctly. Additionally, versions prior to 3.11 do not support PHP 8.

In this PR, I’ve fixed the version range for the jms/serializer dependency to ">3.20 <3.30". This ensures compatibility with PHP 8.3 while avoiding the breaking changes introduced in version 3.3.